### PR TITLE
[BUGFIX] Crash due to empty path in image

### DIFF
--- a/app/src/main/java/com/onelio/connectu/API/LoginRequest.java
+++ b/app/src/main/java/com/onelio/connectu/API/LoginRequest.java
@@ -161,9 +161,8 @@ public class LoginRequest {
                   saveLoginData(); // Save date & version of actual login
                   app.account.Email = user;
                   app.account.Password = pass;
-                  app.account.Name = doc.select("a.dropdown-toggle > span[id=nombre]").text();
-                  app.account.PictureURL =
-                      doc.select("a.dropdown-toggle > span[id=retrato] > img").attr("src");
+                  app.account.Name = doc.getElementById("usunombre").text();
+                  app.account.PictureURL = doc.getElementById("usufoto").children().attr("src");
                   HomeRequest notificationsLoader = new HomeRequest(context);
                   notificationsLoader.parseAlertsFromBody(body);
                 } else {


### PR DESCRIPTION
The application crashed at startup (always) as the `app.account.PictureURL` was empty.

The problem was that the parser could not find the photo/name, this snippet fixes the problem:

```
app.account.Name = doc.getElementById("usunombre").text();
app.account.PictureURL = doc.getElementById("usufoto").children().attr("src");
```

Also nice app ;) check out https://github.com/ecomaikgolf/BUACShell if you're interested.